### PR TITLE
fix(ci): Rely on go version in go.mod

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,13 +1,14 @@
 name: Build and Release
+
 on:
   release:
     types: [created]
+
 jobs:
   build:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: [1.25]
         os: [linux]
         arch: [amd64, arm64]
         include:
@@ -19,25 +20,29 @@ jobs:
             arch: arm64
             goos: linux
             goarch: arm64
+
     steps:
       - name: Set up Go
-        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
-          go-version: ${{ matrix.go-version }}
-      - name: Check out code
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+          go-version-file: go.mod
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
       - name: Set version
         id: version
         run: |
           echo "version=$(git describe --tags --always)" >> $GITHUB_OUTPUT
+
       - name: Build
         run: |
           env CGO_ENABLED=0 GOOS=${{ matrix.goos }} GOARCH=${{ matrix.goarch }} go build -v -ldflags="-X main.version=${{ steps.version.outputs.version }} -w -s" -o hook hook.go
+
       - name: Package Binary
         run: |
           tar -czf hook.tgz hook hook.sh
+
       - name: Upload Release Asset
-        uses: actions/upload-release-asset@e8f9f06c4b078e705bd2ea027f0926603fc9b4d5 # v1
+        uses: actions/upload-release-asset@e8f9f06c4b078e705bd2ea027f0926603fc9b4d5 # v1.0.2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:


### PR DESCRIPTION
This ensures that go version used in the build workflow is the same as
defined in the go.mod file.
